### PR TITLE
changed service to use 'restart' rather than 'start'

### DIFF
--- a/filebeat/config.sls
+++ b/filebeat/config.sls
@@ -22,7 +22,8 @@ filebeat.config:
     - group: root
     - mode: 644
     - watch_in:
-      - service: filebeat.service
+# unfortunately, filebeat is restarted by cmd until tty issues are resolved
+      - cmd: filebeat.service
 
 {% if conf.runlevels_install %}
 filebeat.runlevels_install:

--- a/filebeat/service.sls
+++ b/filebeat/service.sls
@@ -15,9 +15,7 @@ filebeat.pubkeytoauth:
 
 filebeat.service:
   cmd.run:
-    - name: ssh -t -t -o NoHostAuthenticationForLocalhost=yes -i /root/.ssh/filebeat root@localhost "su -c 'service filebeat start'"
-    - unless: 
-      - service filebeat status
+    - name: ssh -t -t -o NoHostAuthenticationForLocalhost=yes -i /root/.ssh/filebeat root@localhost "su -c 'service filebeat restart'"
     - require:
       - pkg: filebeat
       - cmd: filebeat.sshkeygen


### PR DESCRIPTION
this allows:
- service to start as previously implemented
- other states to restart filebeat using watch_in
- 'restart' also returns 0, regardless of prior filebeat service state, so nothing should break

also removed the unless clause, which wasnt working as expected (not starting on config changes)
