### PR TITLE
Add option to enable json input parsing

### DIFF
--- a/filebeat/files/filebeat.jinja
+++ b/filebeat/files/filebeat.jinja
@@ -18,6 +18,12 @@ filebeat:
       force_close_files: {{ log_path.get('force_close_files', 'false') }}
       fields_under_root: {{ log_path.get('fields_under_root', 'false') }}
       close_older: {{ log_path.get('close_older', '1h') }}
+      {%- if log_path.get('json.enabled', False) %}
+      json.message_key: {{ log_path.get('json.message_key', 'json') }}
+      json.keys_under_root: {{ log_path.get('json.keys_under_root', 'true') }}
+      json.add_error_key: {{ log_path.get('json.add_error_key', 'true') }}
+      {%- endif %}
+      
 {%- if 'multiline' in log_path %}
       multiline:
         pattern: "{{ log_path.multiline.get('pattern', '') }}"

--- a/pillar.example
+++ b/pillar.example
@@ -30,7 +30,13 @@ filebeat:
       fields:
         - env: my_environment
         - server_role: webserver
-
+    - 
+      paths:
+        - '/var/log/example/*.json'
+      json.enabled: true
+      json.message_key: json
+      json.keys_under_root: true
+      json.add_error_key: true 
   
   elasticsearch:
     enabled: False


### PR DESCRIPTION
The upcoming version of filebeat allows for parsing json-formatted log paths. This is just a quick patch to add in options for json-formatted log paths as necessary. 

In the pillar data yaml, under the log path configuration options, if json.enabled = true is enabled, the json options are added on. 
