### PR TITLE
Change jinja template formatting of logstash server list to allow for multiple servers

### DIFF
--- a/filebeat/files/filebeat.jinja
+++ b/filebeat/files/filebeat.jinja
@@ -23,7 +23,7 @@ filebeat:
       json.keys_under_root: {{ log_path.get('json.keys_under_root', 'true') }}
       json.add_error_key: {{ log_path.get('json.add_error_key', 'true') }}
       {%- endif %}
-      
+
 {%- if 'multiline' in log_path %}
       multiline:
         pattern: "{{ log_path.multiline.get('pattern', '') }}"
@@ -59,7 +59,7 @@ output:
 
 {%- if logstash.get('enabled', False) %}
   logstash:
-    hosts: ["{{ logstash.server }}"]
+    hosts: {{ logstash.server }}
     worker: 1
     loadbalance: true
     index: filebeat

--- a/pillar.example
+++ b/pillar.example
@@ -10,7 +10,7 @@ filebeat:
       paths:
         - '/var/log/auth.log'
         - '/var/log/syslog'
-    - 
+    -
       paths:
         - '/var/log/apache2/access.log'
       input_type: 'log'
@@ -30,27 +30,27 @@ filebeat:
       fields:
         - env: my_environment
         - server_role: webserver
-    - 
+    -
       paths:
         - '/var/log/example/*.json'
       json.enabled: true
       json.message_key: json
       json.keys_under_root: true
-      json.add_error_key: true 
-  
+      json.add_error_key: true
+
   elasticsearch:
     enabled: False
     server: 127.0.0.1:9200
 
-  logstash: 
+  logstash:
     enabled: True
-    server: 127.0.0.1:5044
+    server:
+      - logstash-shipper1:5044
+      - logstash-shipper2:5044
+
     tls:
       enabled: True
       # this is the public key from your ELK server
       # default path is salt://filebeat/files/ca.pem
-      ssl_cert: salt://mycustom/filebeat/logstash-forwarder.crt 
+      ssl_cert: salt://mycustom/filebeat/logstash-forwarder.crt
       ssl_cert_path: /etc/pki/tls/certs/logstash-forwarder.crt
-
-
-


### PR DESCRIPTION
In the previous formatting of the jinja template for the filebeat conf file, there were some problematic brackets around the variable for specifying logstash servers. While the prior jinja formatting worked fine for just listing a single logstash server, you'd run into issues if you listed multiple servers in your pillar data like this:

```
server:
    - logstash-shipper1:5044
    - logstash-shipper2:5044
```

As it would end up showing up in the filebeat conf file like:

```
output:
  logstash:
    hosts: ["['shipper1:5044', 'shipper2:5044']"]
```

By removing the [" "] around {{ logstash.server }} and specifying the logstash servers as a list in the pillar data, it ends up in a format that is usable for either one or multiple servers:

```
output:
  logstash:
    hosts: ['shipper1:5044', 'shipper2:5044']

```

```
output:
  logstash:
    hosts: ['shipper1:5044']
```

Since having multiple logstash shippers is a common deployment choice for high availability, I've updated the jinja template and the pillar data example to illustrate the change. 
