### PR TITLE
Skip certificate management if none given

### DIFF
--- a/filebeat/config.sls
+++ b/filebeat/config.sls
@@ -1,9 +1,11 @@
 {% from "filebeat/map.jinja" import conf with context %}
 
-{% if salt['pillar.get']('filebeat:logstash:tls:enabled', False)  %}
-{{ salt['pillar.get']('filebeat:logstash:tls:ssl_cert_path', '/etc/pki/tls/certs/logstash-forwarder.crt') }}:
+{% set ssl_cert = salt['pillar.get']('filebeat:logstash:tls:ssl_cert', 'salt://filebeat/files/ca.pem') %}
+{% set ssl_cert_path = salt['pillar.get']('filebeat:logstash:tls:ssl_cert_path') %}
+{% if salt['pillar.get']('filebeat:logstash:tls:enabled', False) and ssl_cert and ssl_cert_path %}
+{{ ssl_cert_path }}:
   file.managed:
-    - source: {{ salt['pillar.get']('filebeat:logstash:tls:ssl_cert', 'salt://filebeat/files/ca.pem') }}
+    - source: {{ ssl_cert }}
     - template: jinja
     - makedirs: True
     - user: root

--- a/filebeat/files/filebeat.jinja
+++ b/filebeat/files/filebeat.jinja
@@ -67,7 +67,9 @@ output:
 {%- if 'tls' in logstash %}
 {%- if logstash.tls.get('enabled', False) %}
     tls:
+{%- if logstash.tls.get('ssl_cert_path') %}
       certificate_authorities: ["{{ logstash.tls.ssl_cert_path }}"]
+{%- endif %}
 {%- endif %}
 {%- endif %}
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -50,7 +50,10 @@ filebeat:
 
     tls:
       enabled: True
-      # this is the public key from your ELK server
-      # default path is salt://filebeat/files/ca.pem
-      ssl_cert: salt://mycustom/filebeat/logstash-forwarder.crt
+      # path to the certificate of your ELK server
+      # set to empty to use system certificates
       ssl_cert_path: /etc/pki/tls/certs/logstash-forwarder.crt
+      # path to the certificate of your ELK server to be installed
+      # default is salt://filebeat/files/ca.pem
+      # set to empty to disable
+      ssl_cert: salt://mycustom/filebeat/logstash-forwarder.crt


### PR DESCRIPTION
# What does this PR fix?

If a certificate_authorities is configured by setting `ssl_cert_path` but no certificate file exists at `salt://filebeat/files/ca.pem`, the `file.managed` state in `filebeat.config` fails.
# Solution

This PR brings the possibility to disable the management of a logstash certificate authority file by setting `ssl_cert` to `None`:

```
filebeat:
  logstash:
    tls:
      ssl_cert:
```

This is not the nicest solution to the problem, but it does not break existing configurations.
## Additional Contents

This PR also adds the ability to disable using custom certificate_authorities, which is also attempted with #11, which seems to be dormant. To disable custom certificate_authorities, set `ssl_cert_path` to `None`:

```
filebeat:
  logstash:
    tls:
      ssl_cert_path:
```
