### PR TITLE
fix support for Debian Jessie

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
   name: docker
   use_sudo: false
   privileged: true
+  username: root
 
 provisioner:
   name: salt_solo

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ filebeat:
 
 Starts the filebeat service. 
 
-**Due to filebeat requiring tty to start, this state uses a SSH loopback to achieve this. (use_vt / sudoers !requiretty did not resolve this on 2015.8.x...)**
-
 
 Testing
 =======

--- a/filebeat/config.sls
+++ b/filebeat/config.sls
@@ -16,6 +16,7 @@
       - filebeat.config
 {% endif %}
 
+{%- if conf.get('log_paths', {}) or conf.get('elasticsearch', {}) or conf.get('logstash', {}) %}
 filebeat.config:
   file.managed:
     - name: {{ conf.config_path }}
@@ -25,11 +26,5 @@ filebeat.config:
     - group: root
     - mode: 644
     - watch_in:
-# unfortunately, filebeat is restarted by cmd until tty issues are resolved
-      - cmd: filebeat.service
-
-{% if conf.runlevels_install %}
-filebeat.runlevels_install:
-  cmd.run:
-    - name: update-rc.d filebeat defaults 95 10
-{% endif %}
+      - service: filebeat
+{%- endif %}

--- a/filebeat/service.sls
+++ b/filebeat/service.sls
@@ -1,22 +1,6 @@
-# filebeat 1.0.0 will not start without tty. use_vt in cmd.run, or sudo with !requiretty in sudoers (default) does not work.
-# this is a hack to get around that issue. 
-filebeat.sshkeygen:
-  cmd.run:
-    - name: ssh-keygen -f /root/.ssh/filebeat -P ""
-    - unless: 
-      - ls /root/.ssh/filebeat
-
-filebeat.pubkeytoauth:
-  cmd.run:
-    - name: cat /root/.ssh/filebeat.pub >> /root/.ssh/authorized_keys
-    - unless: cat /root/.ssh/filebeat.pub | grep -f - /root/.ssh/authorized_keys
-    - require:
-      - cmd: filebeat.sshkeygen
-
-filebeat.service:
-  cmd.run:
-    - name: ssh -t -t -o NoHostAuthenticationForLocalhost=yes -i /root/.ssh/filebeat root@localhost "su -c 'service filebeat restart'"
+start Filebeat service:
+  service.running:
+    - name: filebeat
+    - enable: True
     - require:
       - pkg: filebeat
-      - cmd: filebeat.sshkeygen
-      - cmd: filebeat.pubkeytoauth


### PR DESCRIPTION
* classic service state
* only manage config if certain pillars exist

I could add a condition to the service state that takes care of sysvinit, but Elastic is likely to [only support systemd](https://discuss.elastic.co/t/repackaging-beats-deb-files-service-wont-start/37898/18) in the long-term.