### PR TITLE
Update service handling to use service state.

### DIFF
--- a/filebeat/map.jinja
+++ b/filebeat/map.jinja
@@ -13,12 +13,12 @@
     'RedHat': {
         'config_path': '/etc/filebeat/filebeat.yml',
         'config_source': 'salt://filebeat/files/filebeat.jinja',
-        'runlevels_install': True,
+        'runlevels_install': False,
     },
     'CentOS': {
         'config_path': '/etc/filebeat/filebeat.yml',
         'config_source': 'salt://filebeat/files/filebeat.jinja',
-        'runlevels_install': True,
+        'runlevels_install': False,
     },
     'Suse': {
         'config_path': '/etc/filebeat/filebeat.yml',

--- a/filebeat/service.sls
+++ b/filebeat/service.sls
@@ -1,22 +1,11 @@
-# filebeat 1.0.0 will not start without tty. use_vt in cmd.run, or sudo with !requiretty in sudoers (default) does not work.
-# this is a hack to get around that issue. 
-filebeat.sshkeygen:
-  cmd.run:
-    - name: ssh-keygen -f /root/.ssh/filebeat -P ""
-    - unless: 
-      - ls /root/.ssh/filebeat
-
-filebeat.pubkeytoauth:
-  cmd.run:
-    - name: cat /root/.ssh/filebeat.pub >> /root/.ssh/authorized_keys
-    - unless: cat /root/.ssh/filebeat.pub | grep -f - /root/.ssh/authorized_keys
-    - require:
-      - cmd: filebeat.sshkeygen
+include:
+  - filebeat.install
 
 filebeat.service:
-  cmd.run:
-    - name: ssh -t -t -o NoHostAuthenticationForLocalhost=yes -i /root/.ssh/filebeat root@localhost "su -c 'service filebeat restart'"
+  service.running:
+    - name: filebeat
+    - enable: True
+    - watch:
+      - pkg: filebeat
     - require:
       - pkg: filebeat
-      - cmd: filebeat.sshkeygen
-      - cmd: filebeat.pubkeytoauth


### PR DESCRIPTION
Recent filebeat versions work fine without tty, even the more outdated version pointed to in the default repo config (1.3.1 currently).